### PR TITLE
fix: 책갈피 로직 수정 #62

### DIFF
--- a/src/main/java/com/muud/bookmark/application/BookmarkService.java
+++ b/src/main/java/com/muud/bookmark/application/BookmarkService.java
@@ -38,9 +38,9 @@ public class BookmarkService {
     }
 
     @Transactional
-    public void removeBookmark(Long bookmarkId) {
-        Bookmark bookmark = bookmarkRepository.findById(bookmarkId)
-                .orElseThrow(()->new ApiException(ExceptionType.NOT_FOUND));
+    public void removeBookmark(Long userId, Long diaryId) {
+        Bookmark bookmark = bookmarkRepository.findByUserIdAndDiaryId(userId, diaryId)
+                .orElseThrow(() -> new ApiException(ExceptionType.NOT_FOUND));
         bookmarkRepository.delete(bookmark);
     }
 

--- a/src/main/java/com/muud/bookmark/domain/dto/BookmarkRequest.java
+++ b/src/main/java/com/muud/bookmark/domain/dto/BookmarkRequest.java
@@ -1,4 +1,4 @@
 package com.muud.bookmark.domain.dto;
 
-public record BookmarkRequest(Long userId, Long diaryId) {
+public record BookmarkRequest(Long userId) {
 }

--- a/src/main/java/com/muud/bookmark/domain/dto/BookmarkResponse.java
+++ b/src/main/java/com/muud/bookmark/domain/dto/BookmarkResponse.java
@@ -3,10 +3,12 @@ package com.muud.bookmark.domain.dto;
 import com.muud.bookmark.domain.Bookmark;
 
 public record BookmarkResponse(Long bookmarkId,
-                               Long diaryId) {
+                               Long diaryId,
+                               String content) {
     public static BookmarkResponse from(Bookmark bookmark) {
         return new BookmarkResponse(
                 bookmark.getId(),
-                bookmark.getDiary().getId());
+                bookmark.getDiary().getId(),
+                bookmark.getDiary().getContent());
     }
 }

--- a/src/main/java/com/muud/bookmark/presentation/BookmarkController.java
+++ b/src/main/java/com/muud/bookmark/presentation/BookmarkController.java
@@ -16,26 +16,29 @@ import java.util.List;
 public class BookmarkController {
     private final BookmarkService bookmarkService;
 
-    @GetMapping("/bookmarks")
+    @GetMapping("/diaries/bookmarks")
     public ResponseEntity<List<BookmarkResponse>> getBookmarkResponseList(@RequestBody BookmarkRequest bookmarkRequest) {
         return ResponseEntity.ok(bookmarkService.getBookmarkResponseListByUser(bookmarkRequest.userId()));
     }
 
-    @PostMapping("/bookmarks")
-    public ResponseEntity<Object> addBookmark(@RequestBody BookmarkRequest bookmarkRequest) {
-        Bookmark bookmark = bookmarkService.addBookmark(bookmarkRequest.userId(), bookmarkRequest.diaryId());
-        return ResponseEntity.created(URI.create("/bookmarks/"+bookmark.getId())).build();
-    }
-
-    @GetMapping("/bookmarks/{bookmarkId}")
-    public ResponseEntity<Boolean> checkBookmark(@RequestBody BookmarkRequest bookmarkRequest) {
-        boolean isBookmarked = bookmarkService.isBookmarkedByUser(bookmarkRequest.userId(), bookmarkRequest.diaryId());
+    @GetMapping("/diaries/{diaryId}/bookmarks")
+    public ResponseEntity<Boolean> checkBookmark(@PathVariable("diaryId") Long diaryId,
+                                                 @RequestBody BookmarkRequest bookmarkRequest) {
+        boolean isBookmarked = bookmarkService.isBookmarkedByUser(bookmarkRequest.userId(), diaryId);
         return ResponseEntity.ok(isBookmarked);
     }
 
-    @DeleteMapping("/bookmarks/{bookmarkId}")
-    public ResponseEntity<Object> removeBookmark(@PathVariable("bookmarkId") Long bookmarkId) {
-        bookmarkService.removeBookmark(bookmarkId);
+    @PostMapping("/diaries/{diaryId}/bookmarks")
+    public ResponseEntity<Object> addBookmark(@PathVariable("diaryId") Long diaryId,
+                                              @RequestBody BookmarkRequest bookmarkRequest) {
+        Bookmark bookmark = bookmarkService.addBookmark(bookmarkRequest.userId(), diaryId);
+        return ResponseEntity.created(URI.create("/bookmarks/"+bookmark.getId())).build();
+    }
+
+    @DeleteMapping("/diaries/{diaryId}/bookmarks")
+    public ResponseEntity<Object> removeBookmark(@PathVariable("diaryId") Long diaryId,
+                                                 @RequestBody BookmarkRequest bookmarkRequest) {
+        bookmarkService.removeBookmark(bookmarkRequest.userId(), diaryId);
         return ResponseEntity.noContent().build();
     }
 }


### PR DESCRIPTION
## Summary
책갈피의 로직을 설계했던 방식에 맞도록 변경

## Describe your changes
- 책갈피 제거 로직 변경
- 유저별 책갈피 목록 조회 결과값에 일기내용 추가
- 책갈피 엔드포인트 변경

## Issue number and link
#62