### PR TITLE
feature: 감정별 PlayList 리스트 가져오기 API 추가 , Youtube data 가져오기 기능 구현

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,6 +31,7 @@ jobs:
         kakao.auth.api-key: ${{ secrets.KAKAO_API_KEY }}
         kakao.auth.client-secret: ${{ secrets.KAKAO_CLIENT_SECRET }}
         kakao.auth.redirect-url: ${{ secrets.KAKAO_REDIRECT_URL }}
+        youtube.api-key: ${{ secrets.YOUTUBE_API_KEY }}
     - name: Build with Gradle
       uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
       with:

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,12 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// Youtube API
+	implementation 'com.google.api-client:google-api-client:1.33.0'
+	implementation 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
+	implementation 'com.google.apis:google-api-services-youtube:v3-rev20230816-2.0.0'
+	implementation 'com.google.http-client:google-http-client-jackson2:1.39.2'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/muud/MuudApplication.java
+++ b/src/main/java/com/muud/MuudApplication.java
@@ -3,8 +3,9 @@ package com.muud;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-@EnableJpaAuditing
+@EnableJpaAuditing @EnableScheduling
 @SpringBootApplication
 public class MuudApplication {
 

--- a/src/main/java/com/muud/playlist/controller/PlayListController.java
+++ b/src/main/java/com/muud/playlist/controller/PlayListController.java
@@ -33,11 +33,7 @@ public class PlayListController {
     @GetMapping("/playlists")
     public ResponseEntity<PlayListResponse> getPlayLists(@RequestParam(name = "emotion", required = true) Emotion emotion, @PageableDefault(size = 4) Pageable pageable){
         Page<VideoDto> videoDtoList = playListService.getPlayLists(emotion, pageable);
-        List<String> ids = videoDtoList
-                .map(videoDto -> videoDto.getVideoId())
-                .stream().collect(Collectors.toList());
         return ResponseEntity.ok(PlayListResponse.from(videoDtoList));
-
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/com/muud/playlist/controller/PlayListController.java
+++ b/src/main/java/com/muud/playlist/controller/PlayListController.java
@@ -32,16 +32,11 @@ public class PlayListController {
     private final YoutubeDataService youtubeDataService;
     @GetMapping("/playlists")
     public ResponseEntity<PlayListResponse> getPlayLists(@RequestParam(name = "emotion", required = true) Emotion emotion, @PageableDefault(size = 4) Pageable pageable){
-
-        try {
-            Page<VideoDto> videoDtoList = playListService.getPlayLists(emotion, pageable);
-            List<String> ids = videoDtoList.map(videoDto -> videoDto.getVideoId())
-                    .stream().collect(Collectors.toList());
-            youtubeDataService.getVideoDetails(ids);
-            return ResponseEntity.ok(PlayListResponse.from(videoDtoList));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        Page<VideoDto> videoDtoList = playListService.getPlayLists(emotion, pageable);
+        List<String> ids = videoDtoList
+                .map(videoDto -> videoDto.getVideoId())
+                .stream().collect(Collectors.toList());
+        return ResponseEntity.ok(PlayListResponse.from(videoDtoList));
 
     }
 

--- a/src/main/java/com/muud/playlist/controller/PlayListController.java
+++ b/src/main/java/com/muud/playlist/controller/PlayListController.java
@@ -1,0 +1,55 @@
+package com.muud.playlist.controller;
+
+import com.muud.emotion.entity.Emotion;
+import com.muud.global.error.ExceptionType;
+import com.muud.global.error.ResponseError;
+import com.muud.playlist.dto.PlayListResponse;
+import com.muud.playlist.dto.VideoDto;
+import com.muud.playlist.service.PlayListService;
+import com.muud.playlist.service.YoutubeDataService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Controller
+@RequiredArgsConstructor
+public class PlayListController {
+    private final PlayListService playListService;
+    private final YoutubeDataService youtubeDataService;
+    @GetMapping("/playlists")
+    public ResponseEntity<PlayListResponse> getPlayLists(@RequestParam(name = "emotion", required = true) Emotion emotion, @PageableDefault(size = 4) Pageable pageable){
+
+        try {
+            Page<VideoDto> videoDtoList = playListService.getPlayLists(emotion, pageable);
+            List<String> ids = videoDtoList.map(videoDto -> videoDto.getVideoId())
+                    .stream().collect(Collectors.toList());
+            youtubeDataService.getVideoDetails(ids);
+            return ResponseEntity.ok(PlayListResponse.from(videoDtoList));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<ResponseError> handleInvalidEnumValueException(IllegalArgumentException ex) {
+        return ResponseEntity.badRequest()
+                .body(new ResponseError(ExceptionType.INVALID_INPUT_VALUE.getMessage()));
+    }
+
+}

--- a/src/main/java/com/muud/playlist/dto/PlayListResponse.java
+++ b/src/main/java/com/muud/playlist/dto/PlayListResponse.java
@@ -1,0 +1,26 @@
+package com.muud.playlist.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class PlayListResponse {
+    private int totalCount;
+    private List<VideoDto> playlists = new ArrayList<>();
+
+    @Builder
+    public PlayListResponse(int totalCount, List<VideoDto> playlists) {
+        this.totalCount = totalCount;
+        this.playlists = playlists;
+    }
+    public static PlayListResponse from(Page<VideoDto> videoDtoPage){
+        return PlayListResponse.builder()
+                .totalCount(videoDtoPage.getSize())
+                .playlists(videoDtoPage.stream().toList())
+                .build();
+    }
+}

--- a/src/main/java/com/muud/playlist/dto/VideoDto.java
+++ b/src/main/java/com/muud/playlist/dto/VideoDto.java
@@ -1,0 +1,21 @@
+package com.muud.playlist.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.persistence.Column;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+@Getter @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class VideoDto {
+    private Long id;
+    private String title;
+    private String videoId;
+    private String channelName;
+    private List<String> tags;
+    private String description;
+}

--- a/src/main/java/com/muud/playlist/entity/PlayList.java
+++ b/src/main/java/com/muud/playlist/entity/PlayList.java
@@ -1,0 +1,47 @@
+package com.muud.playlist.entity;
+
+import com.google.api.services.youtube.model.SearchResult;
+import com.muud.emotion.entity.Emotion;
+import com.muud.global.common.BaseEntity;
+import com.muud.playlist.dto.VideoDto;
+import com.muud.playlist.repository.PlayListRepository;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlayList extends BaseEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "playlist_id")
+    private Long id;
+    private String title;
+    private String videoId;
+    private String channelName;
+    @Enumerated(value = EnumType.STRING)
+    private Emotion emotion;
+
+    @Builder
+    public PlayList(String title, String videoId, String channelName, Emotion emotion) {
+        this.title = title;
+        this.videoId = videoId;
+        this.channelName = channelName;
+        this.emotion = emotion;
+    }
+
+    public VideoDto toDto(){
+        return VideoDto.builder()
+                .id(id)
+                .videoId(videoId)
+                .title(title)
+                .build();
+    }
+    public static PlayList from(SearchResult searchResult, Emotion emotion){
+        return PlayList.builder()
+                .title(searchResult.getSnippet().getTitle())
+                .videoId(searchResult.getId().getVideoId())
+                .channelName(searchResult.getSnippet().getChannelTitle())
+                .emotion(emotion)
+                .build();
+    }
+}

--- a/src/main/java/com/muud/playlist/entity/PlayList.java
+++ b/src/main/java/com/muud/playlist/entity/PlayList.java
@@ -1,14 +1,15 @@
 package com.muud.playlist.entity;
 
-import com.google.api.services.youtube.model.SearchResult;
 import com.muud.emotion.entity.Emotion;
 import com.muud.global.common.BaseEntity;
 import com.muud.playlist.dto.VideoDto;
-import com.muud.playlist.repository.PlayListRepository;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
+
+import java.util.*;
+
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PlayList extends BaseEntity {
@@ -20,13 +21,14 @@ public class PlayList extends BaseEntity {
     private String channelName;
     @Enumerated(value = EnumType.STRING)
     private Emotion emotion;
-
+    private String tags;
     @Builder
-    public PlayList(String title, String videoId, String channelName, Emotion emotion) {
+    public PlayList(String title, String videoId, String channelName, Emotion emotion, List<String> tags) {
         this.title = title;
         this.videoId = videoId;
         this.channelName = channelName;
         this.emotion = emotion;
+        this.tags = convertTagsToString(tags);
     }
 
     public VideoDto toDto(){
@@ -34,14 +36,18 @@ public class PlayList extends BaseEntity {
                 .id(id)
                 .videoId(videoId)
                 .title(title)
+                .tags(convertTagsToList(tags))
+                .channelName(channelName)
                 .build();
     }
-    public static PlayList from(SearchResult searchResult, Emotion emotion){
-        return PlayList.builder()
-                .title(searchResult.getSnippet().getTitle())
-                .videoId(searchResult.getId().getVideoId())
-                .channelName(searchResult.getSnippet().getChannelTitle())
-                .emotion(emotion)
-                .build();
+    public String convertTagsToString(List<String> tagList){
+        StringBuilder sb = new StringBuilder();
+        tagList.forEach(t -> sb.append(t+";"));
+        return sb.toString();
+    }
+    public List<String> convertTagsToList(String tags){
+        if(tags!=null)
+            return Arrays.stream(tags.split(";")).toList();
+        return Collections.EMPTY_LIST;
     }
 }

--- a/src/main/java/com/muud/playlist/repository/PlayListRepository.java
+++ b/src/main/java/com/muud/playlist/repository/PlayListRepository.java
@@ -1,0 +1,15 @@
+package com.muud.playlist.repository;
+
+import com.muud.emotion.entity.Emotion;
+import com.muud.playlist.entity.PlayList;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface PlayListRepository extends JpaRepository<PlayList, Long> {
+    @Query("SELECT p from PlayList p where p.emotion = :emotion order by rand()")
+    Page<PlayList> findByEmotion(Emotion emotion, Pageable pageable);
+}

--- a/src/main/java/com/muud/playlist/service/PlayListService.java
+++ b/src/main/java/com/muud/playlist/service/PlayListService.java
@@ -1,0 +1,28 @@
+package com.muud.playlist.service;
+
+import com.muud.emotion.entity.Emotion;
+import com.muud.playlist.dto.VideoDto;
+import com.muud.playlist.entity.PlayList;
+import com.muud.playlist.repository.PlayListRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PlayListService {
+    private final PlayListRepository playListRepository;
+    public Page<VideoDto> getPlayLists(Emotion emotion, Pageable pageable){
+        return playListRepository.findByEmotion(emotion, pageable)
+               .map(PlayList::toDto);
+    }
+}

--- a/src/main/java/com/muud/playlist/service/YoutubeDataService.java
+++ b/src/main/java/com/muud/playlist/service/YoutubeDataService.java
@@ -1,0 +1,87 @@
+package com.muud.playlist.service;
+
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.youtube.YouTube;
+import com.google.api.services.youtube.model.SearchListResponse;
+import com.google.api.services.youtube.model.Video;
+import com.muud.emotion.entity.Emotion;
+import com.muud.playlist.entity.PlayList;
+import com.muud.playlist.repository.PlayListRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor @Slf4j
+public class YoutubeDataService {
+    @Value("${youtube.api-key}")
+    private String apiKey;
+    private final PlayListRepository playListRepository;
+
+    @Scheduled(cron = "0 10 0 * * ?", zone = "Asia/Seoul")
+    public void updateVideoList() throws IOException {
+        log.info("playlist data refresh schedule start");
+        // JSON 데이터를 처리하기 위한 JsonFactory 객체 생성
+        JsonFactory jsonFactory = new JacksonFactory();
+        playListRepository.deleteAll();
+
+        // YouTube 객체를 빌드하여 API에 접근할 수 있는 YouTube 클라이언트 생성
+        YouTube youtube = new YouTube.Builder(
+                new com.google.api.client.http.javanet.NetHttpTransport(),
+                jsonFactory,
+                request -> {})
+                .build();
+
+        // YouTube Search API를 사용하여 동영상 검색을 위한 요청 객체 생성
+        YouTube.Search.List search = youtube.search().list(Collections.singletonList("snippet"));
+
+        // API 설정
+        search.setKey(apiKey);
+        search.setMaxResults(30l);
+        search.setOrder("rating");
+        search.setType(Collections.singletonList("video"));
+        search.setVideoEmbeddable("true");
+        search.setVideoDuration("long");
+        List<PlayList> playLists = new ArrayList<>();
+        for(Emotion emotion: Emotion.values()){
+            // 검색어 설정
+            search.setQ(emotion.getTitleEmotion()+" PlayList");
+            SearchListResponse searchResponse = search.execute();
+
+            // 검색 결과에서 동영상 목록 가져오기
+            playLists.addAll(searchResponse.getItems().stream()
+                    .map(r -> PlayList.from(r, emotion))
+                    .collect(Collectors.toList()));
+        }
+        savePlayList(playLists);
+    }
+    public void savePlayList(List<PlayList> playListList){
+        playListRepository.saveAll(playListList);
+    }
+
+    public Map<String, List<String>> getVideoDetails(List<String> videoIds) throws IOException {
+        JsonFactory jsonFactory = new JacksonFactory();
+        YouTube youtube = new YouTube.Builder(
+                new com.google.api.client.http.javanet.NetHttpTransport(),
+                jsonFactory,
+                request -> {})
+                .build();
+        YouTube.Videos.List request = youtube.videos()
+                .list(Collections.singletonList("snippet"));
+        request.setKey(apiKey)
+                .setId(videoIds);
+        List<Video> videoList = request.execute().getItems();
+        Map<String, List<String>> tagsMap = new HashMap<>();
+        videoList.forEach(video -> {
+            tagsMap.put(video.getId(), video.getSnippet().getTags());
+        });
+        return tagsMap;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,3 +34,5 @@ kakao:
     api-key: ${KAKAO_API_KEY}
     client-secret: ${KAKAO_CLIENT_SECRET}
     redirect-url: ${KAKAO_REDIRECT_URL}
+youtube:
+  api-key: ${YOUTUBE_API_KEY}


### PR DESCRIPTION
## Summary
감정별 PlayList 리스트 가져오기 API 추가 , Youtube data  API로 리스트 가져와 저장

## Describe your changes
-PlayList Entity 생성
-감정과 관련된 PlayList 가져오기 API 구현
-Youtube Search, Video API로 가져온 데이터 PlayList 테이블에 저장하는 스캐줄 작업 추가(시간 수정 필요)

## Issue number and link
#54 