### PR TITLE
refactor: 인증 Interceptor에서 annotation 체크로 변경, 본인 확인 로직 추가

### DIFF
--- a/src/main/java/com/muud/auth/jwt/Auth.java
+++ b/src/main/java/com/muud/auth/jwt/Auth.java
@@ -1,0 +1,10 @@
+package com.muud.auth.jwt;
+
+import java.lang.annotation.*;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface Auth {
+
+}

--- a/src/main/java/com/muud/auth/jwt/JwtInterceptor.java
+++ b/src/main/java/com/muud/auth/jwt/JwtInterceptor.java
@@ -12,20 +12,27 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
 public class JwtInterceptor implements HandlerInterceptor {
     private final JwtTokenUtils jwtTokenUtils;
     private final AuthService authService;
+
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         if(request.getMethod().equals("OPTIONS")) {
             return true;
         }
+        if(((HandlerMethod)handler).getMethodAnnotation(Auth.class) == null){
+            return true;
+        }
         String token = request.getHeader(HttpHeaders.AUTHORIZATION);
-        // 토큰이 없으면 요청 거부
         if (token == null || !token.startsWith("Bearer ")) {
             throw new ApiException(ExceptionType.ACCESS_DENIED_EXCEPTION);
         }else{

--- a/src/main/java/com/muud/global/config/WebConfig.java
+++ b/src/main/java/com/muud/global/config/WebConfig.java
@@ -21,14 +21,14 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowCredentials(true);
     }
 
-    private String[] excludePathPatterns = {
-            "/auth/**", "/auth/kakao/signin"
-    };
+//    private String[] excludePathPatterns = {
+//            "/auth/**", "/auth/kakao/signin"
+//    };
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(jwtInterceptor)
-                .addPathPatterns("/**")
-                .excludePathPatterns(excludePathPatterns);
+        registry.addInterceptor(jwtInterceptor);
+//                .addPathPatterns("/**")
+//                .excludePathPatterns(excludePathPatterns);
     }
 }

--- a/src/main/java/com/muud/user/controller/UserController.java
+++ b/src/main/java/com/muud/user/controller/UserController.java
@@ -1,6 +1,10 @@
 package com.muud.user.controller;
 
+import com.muud.auth.jwt.Auth;
+import com.muud.global.error.ApiException;
+import com.muud.global.error.ExceptionType;
 import com.muud.user.dto.UserInfo;
+import com.muud.user.entity.User;
 import com.muud.user.service.UserService;
 import jakarta.websocket.server.PathParam;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.Map;
@@ -16,8 +21,12 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
+    @Auth
     @PatchMapping("/users/{userId}/nickname")
-    public ResponseEntity updateUserNickname(@PathVariable("userId") Long userId, @RequestBody Map<String, String> mapNickname){
+    public ResponseEntity updateUserNickname(@RequestAttribute User user, @PathVariable("userId") Long userId, @RequestBody Map<String, String> mapNickname){
+        if(!user.getId().equals(userId)){
+            throw new ApiException(ExceptionType.FORBIDDEN_USER);
+        }
         UserInfo userInfo = userService.changeUserNickname(userId, mapNickname.get("nickname"));
         return ResponseEntity.ok(userInfo);
     }


### PR DESCRIPTION
## Summary
본인의 리소스만 접근 가능하도록 
## Describe your changes
-확장과 둘러보기 기능을 고려하여 addPathPatterns, excludePatterns에서 annotation 확인 방식으로 변경
-닉네임 변경 요청시 user 본인인지 확인하는 로직 추가
## Issue number and link
#86 