### PR TITLE
Fix/#80 user와 diary 연동

### DIFF
--- a/src/main/java/com/muud/diary/application/DiaryService.java
+++ b/src/main/java/com/muud/diary/application/DiaryService.java
@@ -33,8 +33,8 @@ public class DiaryService {
                 .orElseThrow(IllegalArgumentException::new));
     }
 
-    public List<DiaryResponse> getDiaryResponseListByYearMonth(YearMonth yearMonth) {
-        List<Diary> diaryList = diaryRepository.findByMonthAndYear(yearMonth.getMonthValue(), yearMonth.getYear());
+    public List<DiaryResponse> getDiaryResponseListByYearMonth(Long userId, YearMonth yearMonth) {
+        List<Diary> diaryList = diaryRepository.findByMonthAndYear(userId, yearMonth.getMonthValue(), yearMonth.getYear());
         return diaryList.stream()
                 .map(DiaryResponse::from)
                 .collect(Collectors.toList());

--- a/src/main/java/com/muud/diary/application/DiaryService.java
+++ b/src/main/java/com/muud/diary/application/DiaryService.java
@@ -59,20 +59,25 @@ public class DiaryService {
         return diaryRepository.findAll();
     }
 
-    public List<DiaryPreviewResponse> getDiaryResponseListByEmotion(Emotion emotion) {
-        List<Diary> diaryList = diaryRepository.findByEmotion(emotion);
+    public List<DiaryPreviewResponse> getDiaryResponseListByEmotion(Long userId, Emotion emotion) {
+        List<Diary> diaryList = diaryRepository.findByEmotion(userId, emotion);
+
+        if (!diaryList.isEmpty()) {
+            checkForbiddenUser(userId, diaryList.get(0));
+        }
+
         return diaryList.stream()
                 .map(DiaryPreviewResponse::from)
                 .collect(Collectors.toList());
     }
 
     private void checkForbiddenUser(Long userId, Diary diary) {
-        if (isOwnerOfDiary(userId, diary)) {
+        if (!isOwnerOfDiary(userId, diary)) {
             throw new ApiException(ExceptionType.FORBIDDEN_USER);
         }
     }
 
     private Boolean isOwnerOfDiary(Long userId, Diary diary) {
-        return diary.getId().equals(userId);
+        return diary.getUser().getId().equals(userId);
     }
 }

--- a/src/main/java/com/muud/diary/application/DiaryService.java
+++ b/src/main/java/com/muud/diary/application/DiaryService.java
@@ -30,9 +30,11 @@ public class DiaryService {
                         user));
     }
 
-    public DiaryResponse getDiaryResponse(Long diaryId) {
-        return DiaryResponse.from(diaryRepository.findById(diaryId)
-                .orElseThrow(IllegalArgumentException::new));
+    public DiaryResponse getDiaryResponse(Long userId, Long diaryId) {
+        Diary diary = diaryRepository.findById(diaryId)
+                .orElseThrow(IllegalArgumentException::new);
+        checkForbiddenUser(userId, diary);
+        return DiaryResponse.from(diary);
     }
 
     public List<DiaryResponse> getDiaryResponseListByYearMonth(Long userId, YearMonth yearMonth) {

--- a/src/main/java/com/muud/diary/application/DiaryService.java
+++ b/src/main/java/com/muud/diary/application/DiaryService.java
@@ -6,6 +6,7 @@ import com.muud.diary.dto.DiaryRequest;
 import com.muud.diary.dto.DiaryResponse;
 import com.muud.diary.repository.DiaryRepository;
 import com.muud.emotion.entity.Emotion;
+import com.muud.user.entity.User;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,10 +21,11 @@ public class DiaryService {
     private final DiaryRepository diaryRepository;
 
     @Transactional
-    public Diary writeDiary(DiaryRequest diaryRequest) {
+    public Diary writeDiary(User user, DiaryRequest diaryRequest) {
         return diaryRepository.save(
                 new Diary(diaryRequest.content(),
-                        Emotion.valueOf(diaryRequest.emotionName().toUpperCase())));
+                        Emotion.valueOf(diaryRequest.emotionName().toUpperCase()),
+                        user));
     }
 
     public DiaryResponse getDiaryResponse(Long diaryId) {

--- a/src/main/java/com/muud/diary/domain/Diary.java
+++ b/src/main/java/com/muud/diary/domain/Diary.java
@@ -3,6 +3,7 @@ package com.muud.diary.domain;
 import com.muud.bookmark.domain.Bookmark;
 import com.muud.emotion.entity.Emotion;
 import com.muud.global.common.BaseEntity;
+import com.muud.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -34,9 +35,9 @@ public class Diary extends BaseEntity {
 //    @Column
 //    private String imageUrl;
 
-//    @NotNull
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
 //    @NotNull
 //    @ManyToOne(fetch = FetchType.LAZY)
@@ -45,10 +46,11 @@ public class Diary extends BaseEntity {
     @OneToMany(mappedBy = "diary")
     private List<Bookmark> bookmarkList;
 
-    public Diary(String content, Emotion emotion) {
+    public Diary(String content, Emotion emotion, User user) {
         this.id = null;
         this.content = content;
         this.emotion = emotion;
+        this.user = user;
     }
 
     public void updateContent(String content) {

--- a/src/main/java/com/muud/diary/presentation/DiaryController.java
+++ b/src/main/java/com/muud/diary/presentation/DiaryController.java
@@ -6,6 +6,7 @@ import com.muud.diary.dto.DiaryPreviewResponse;
 import com.muud.diary.dto.DiaryRequest;
 import com.muud.diary.dto.DiaryResponse;
 import com.muud.emotion.entity.Emotion;
+import com.muud.user.entity.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,9 +23,9 @@ public class DiaryController {
     private final DiaryService diaryService;
 
     @PostMapping("/diaries")
-    public ResponseEntity<Object> writeDiary(@Valid @RequestBody DiaryRequest diaryRequest) {
-
-        Diary diary = diaryService.writeDiary(diaryRequest);
+    public ResponseEntity<Object> writeDiary(@RequestAttribute("user") User user,
+                                             @Valid @RequestBody DiaryRequest diaryRequest) {
+        Diary diary = diaryService.writeDiary(user, diaryRequest);
         return ResponseEntity.created(URI.create("/diaries/"+diary.getId())).build();
     }
 

--- a/src/main/java/com/muud/diary/presentation/DiaryController.java
+++ b/src/main/java/com/muud/diary/presentation/DiaryController.java
@@ -31,9 +31,11 @@ public class DiaryController {
         return ResponseEntity.created(URI.create("/diaries/"+diary.getId())).build();
     }
 
+    @Auth
     @GetMapping("/diaries/{diaryId}")
-    public ResponseEntity<DiaryResponse> getDiaryResponse(@PathVariable("diaryId") Long diaryId) {
-        return ResponseEntity.ok(diaryService.getDiaryResponse(diaryId));
+    public ResponseEntity<DiaryResponse> getDiaryResponse(@RequestAttribute("user") User user,
+                                                          @PathVariable("diaryId") Long diaryId) {
+        return ResponseEntity.ok(diaryService.getDiaryResponse(user.getId(), diaryId));
     }
 
     @Auth

--- a/src/main/java/com/muud/diary/presentation/DiaryController.java
+++ b/src/main/java/com/muud/diary/presentation/DiaryController.java
@@ -44,10 +44,12 @@ public class DiaryController {
         return ResponseEntity.ok(diaryService.getDiaryResponseListByYearMonth(user.getId(), yearMonth));
     }
 
+    @Auth
     @PutMapping("/diaries/{diaryId}")
-    public ResponseEntity<DiaryResponse> updatePost(@PathVariable("diaryId") Long diaryId,
+    public ResponseEntity<DiaryResponse> updatePost(@RequestAttribute("user") User user,
+                                                    @PathVariable("diaryId") Long diaryId,
                                                     @Valid @RequestBody DiaryRequest diaryRequest) {
-        return ResponseEntity.ok(diaryService.updateContent(diaryId, diaryRequest));
+        return ResponseEntity.ok(diaryService.updateContent(user.getId(), diaryId, diaryRequest));
     }
 
     @GetMapping("/diaries/emotion")

--- a/src/main/java/com/muud/diary/presentation/DiaryController.java
+++ b/src/main/java/com/muud/diary/presentation/DiaryController.java
@@ -1,5 +1,6 @@
 package com.muud.diary.presentation;
 
+import com.muud.auth.jwt.Auth;
 import com.muud.diary.application.DiaryService;
 import com.muud.diary.domain.Diary;
 import com.muud.diary.dto.DiaryPreviewResponse;
@@ -22,6 +23,7 @@ import java.util.List;
 public class DiaryController {
     private final DiaryService diaryService;
 
+    @Auth
     @PostMapping("/diaries")
     public ResponseEntity<Object> writeDiary(@RequestAttribute("user") User user,
                                              @Valid @RequestBody DiaryRequest diaryRequest) {
@@ -34,10 +36,12 @@ public class DiaryController {
         return ResponseEntity.ok(diaryService.getDiaryResponse(diaryId));
     }
 
+    @Auth
     @GetMapping("/diaries/month")
-    public ResponseEntity<List<DiaryResponse>> getDiaryResponseListByYearMonth(@RequestParam(name = "date", required = true) String date) {
+    public ResponseEntity<List<DiaryResponse>> getDiaryResponseListByYearMonth(@RequestAttribute("user") User user,
+                                                                               @RequestParam(name = "date", required = true) String date) {
         YearMonth yearMonth = YearMonth.parse(date, DateTimeFormatter.ofPattern("yyyy-MM"));
-        return ResponseEntity.ok(diaryService.getDiaryResponseListByYearMonth(yearMonth));
+        return ResponseEntity.ok(diaryService.getDiaryResponseListByYearMonth(user.getId(), yearMonth));
     }
 
     @PutMapping("/diaries/{diaryId}")

--- a/src/main/java/com/muud/diary/presentation/DiaryController.java
+++ b/src/main/java/com/muud/diary/presentation/DiaryController.java
@@ -52,8 +52,10 @@ public class DiaryController {
         return ResponseEntity.ok(diaryService.updateContent(user.getId(), diaryId, diaryRequest));
     }
 
+    @Auth
     @GetMapping("/diaries/emotion")
-    public ResponseEntity<List<DiaryPreviewResponse>> getDiaryResponseListByEmotion(@RequestParam(name = "emotion", required = true) Emotion emotion) {
-        return ResponseEntity.ok(diaryService.getDiaryResponseListByEmotion(emotion));
+    public ResponseEntity<List<DiaryPreviewResponse>> getDiaryResponseListByEmotion(@RequestAttribute("user") User user,
+                                                                                    @RequestParam(name = "emotion", required = true) Emotion emotion) {
+        return ResponseEntity.ok(diaryService.getDiaryResponseListByEmotion(user.getId(), emotion));
     }
 }

--- a/src/main/java/com/muud/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/muud/diary/repository/DiaryRepository.java
@@ -20,6 +20,10 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
                                    @Param("month") int month,
                                    @Param("year") int year);
 
-    @Query("SELECT d FROM Diary d WHERE d.emotion = :emotion")
-    List<Diary> findByEmotion(@Param("emotion") Emotion emotion);
+    @Query("SELECT d " +
+            "FROM Diary d " +
+            "WHERE d.user.id = :userId " +
+            "AND d.emotion = :emotion")
+    List<Diary> findByEmotion(@Param("userId") Long userId,
+                              @Param("emotion") Emotion emotion);
 }

--- a/src/main/java/com/muud/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/muud/diary/repository/DiaryRepository.java
@@ -11,8 +11,14 @@ import java.util.List;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
-    @Query("SELECT d FROM Diary d WHERE MONTH(d.createdDate) = :month AND YEAR(d.createdDate) = :year")
-    List<Diary> findByMonthAndYear(@Param("month") int month, @Param("year") int year);
+    @Query("SELECT d " +
+            "FROM Diary d " +
+            "WHERE d.user.id = :userId " +
+            "AND MONTH(d.createdDate) = :month " +
+            "AND YEAR(d.createdDate) = :year")
+    List<Diary> findByMonthAndYear(@Param("userId") Long userId,
+                                   @Param("month") int month,
+                                   @Param("year") int year);
 
     @Query("SELECT d FROM Diary d WHERE d.emotion = :emotion")
     List<Diary> findByEmotion(@Param("emotion") Emotion emotion);


### PR DESCRIPTION
## Summary
user와 diary 연동

## Describe your changes
- write 메서드에 user 정보 추가
- 본인이 작성한 일기만 월별 조회 가능하도록 로직 변경
- 일기 수정 기능에 유저 정보 체크 메서드 추가
- 감정별 일기 조회 실행 전 유저 정보 체크하도록 수정
- 일기 상세 조회 메서드에 사용자 일치 여부 확인하도록 수정

## Issue number and link
#80