### PR TITLE
refactor: 예외 처리 시스템 개편 #143

### DIFF
--- a/src/main/java/com/muud/bookmark/exception/BookmarkErrorCode.java
+++ b/src/main/java/com/muud/bookmark/exception/BookmarkErrorCode.java
@@ -1,0 +1,38 @@
+package com.muud.bookmark.exception;
+
+import com.muud.global.exception.support.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum BookmarkErrorCode implements ErrorCode {
+
+    BOOKMARK_ALREADY_EXISTS("이미 추가된 북마크입니다.", HttpStatus.CONFLICT),
+    USER_NOT_FOUND("북마크 추가 중 해당 유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    DIARY_NOT_FOUND("북마크 추가 중 해당 일기를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    BOOKMARK_NOT_FOUND("북마크를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    DEFAULT("북마크 취급 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String message;
+    private final HttpStatus status;
+
+    @Override
+    public String defaultMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus defaultHttpStatus() {
+        return status;
+    }
+
+    @Override
+    public BookmarkException defaultException() {
+        return new BookmarkException(this);
+    }
+
+    @Override
+    public BookmarkException defaultException(Throwable cause) {
+        return new BookmarkException(this, cause);
+    }
+}

--- a/src/main/java/com/muud/bookmark/exception/BookmarkException.java
+++ b/src/main/java/com/muud/bookmark/exception/BookmarkException.java
@@ -1,0 +1,27 @@
+package com.muud.bookmark.exception;
+
+import com.muud.global.exception.support.CustomException;
+import com.muud.global.exception.support.ErrorCode;
+
+public class BookmarkException extends CustomException {
+
+    public BookmarkException() {
+        super();
+    }
+
+    public BookmarkException(String message) {
+        super(message);
+    }
+
+    public BookmarkException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public BookmarkException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public BookmarkException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+}

--- a/src/main/java/com/muud/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/muud/bookmark/service/BookmarkService.java
@@ -5,8 +5,6 @@ import com.muud.bookmark.domain.dto.BookmarkResponse;
 import com.muud.bookmark.repository.BookmarkRepository;
 import com.muud.diary.domain.Diary;
 import com.muud.diary.repository.DiaryRepository;
-import com.muud.global.error.ApiException;
-import com.muud.global.error.ExceptionType;
 import com.muud.user.entity.User;
 import com.muud.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +13,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.muud.bookmark.exception.BookmarkErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -28,13 +28,13 @@ public class BookmarkService {
     @Transactional
     public Bookmark addBookmark(final Long userId, final Long diaryId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(()->new ApiException(ExceptionType.NOT_FOUND));
+                .orElseThrow(USER_NOT_FOUND::defaultException);
 
         Diary diary = diaryRepository.findById(diaryId)
-                .orElseThrow(()->new ApiException(ExceptionType.NOT_FOUND));
+                .orElseThrow(DIARY_NOT_FOUND::defaultException);
 
         if (isBookmarked(userId, diaryId)) {
-            throw new ApiException(ExceptionType.BAD_REQUEST);
+            throw BOOKMARK_ALREADY_EXISTS.defaultException();
         }
         return bookmarkRepository.save(new Bookmark(user, diary));
     }
@@ -42,7 +42,7 @@ public class BookmarkService {
     @Transactional
     public void removeBookmark(final Long userId, final Long diaryId) {
         Bookmark bookmark = bookmarkRepository.findByUserIdAndDiaryId(userId, diaryId)
-                .orElseThrow(() -> new ApiException(ExceptionType.NOT_FOUND));
+                .orElseThrow(BOOKMARK_NOT_FOUND::defaultException);
         bookmarkRepository.delete(bookmark);
     }
 
@@ -57,5 +57,3 @@ public class BookmarkService {
         return bookmarkRepository.findByUserIdAndDiaryId(userId, diaryId).isPresent();
     }
 }
-
-

--- a/src/main/java/com/muud/diary/exception/DiaryErrorCode.java
+++ b/src/main/java/com/muud/diary/exception/DiaryErrorCode.java
@@ -1,0 +1,37 @@
+package com.muud.diary.exception;
+
+import com.muud.global.exception.support.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum DiaryErrorCode implements ErrorCode {
+
+    DIARY_ACCESS_DENIED("해당 일기에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    DIARY_ALREADY_EXISTS("해당 날짜에 이미 작성된 일기가 있습니다.", HttpStatus.CONFLICT),
+    DIARY_NOT_FOUND("해당 일기를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    DEFAULT("일기 취급 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String message;
+    private final HttpStatus status;
+
+    @Override
+    public String defaultMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus defaultHttpStatus() {
+        return status;
+    }
+
+    @Override
+    public DiaryException defaultException() {
+        return new DiaryException(this);
+    }
+
+    @Override
+    public DiaryException defaultException(Throwable cause) {
+        return new DiaryException(this, cause);
+    }
+}

--- a/src/main/java/com/muud/diary/exception/DiaryException.java
+++ b/src/main/java/com/muud/diary/exception/DiaryException.java
@@ -1,0 +1,27 @@
+package com.muud.diary.exception;
+
+import com.muud.global.exception.support.CustomException;
+import com.muud.global.exception.support.ErrorCode;
+
+public class DiaryException extends CustomException {
+
+    public DiaryException() {
+        super();
+    }
+
+    public DiaryException(String message) {
+        super(message);
+    }
+
+    public DiaryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DiaryException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public DiaryException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+}

--- a/src/main/java/com/muud/diary/service/DiaryService.java
+++ b/src/main/java/com/muud/diary/service/DiaryService.java
@@ -4,8 +4,6 @@ import com.muud.diary.domain.Diary;
 import com.muud.diary.domain.dto.*;
 import com.muud.diary.repository.DiaryRepository;
 import com.muud.emotion.domain.Emotion;
-import com.muud.global.error.ApiException;
-import com.muud.global.error.ExceptionType;
 import com.muud.playlist.domain.PlayList;
 import com.muud.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +13,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.YearMonth;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.muud.diary.exception.DiaryErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -36,7 +36,7 @@ public class DiaryService {
     public DiaryResponse getDiary(final User user,
                                   final Long diaryId) {
         Diary diary = diaryRepository.findById(diaryId)
-                .orElseThrow(IllegalArgumentException::new);
+                .orElseThrow(DIARY_NOT_FOUND::defaultException);
         validateDiaryOwnership(user, diary);
         return DiaryResponse.from(diary);
     }
@@ -55,7 +55,7 @@ public class DiaryService {
                                        final Long diaryId,
                                        final ContentUpdateRequest contentUpdateRequest) {
         Diary diary = diaryRepository.findById(diaryId)
-                .orElseThrow(IllegalArgumentException::new);
+                .orElseThrow(DIARY_NOT_FOUND::defaultException);
         validateDiaryOwnership(user, diary);
         diary.updateContent(contentUpdateRequest.content());
         Diary updatedDiary = diaryRepository.save(diary);
@@ -83,7 +83,7 @@ public class DiaryService {
     private void validateDiaryOwnership(final User user,
                                         final Diary diary) {
         if (!user.checkValidId(diary.getUser().getId())) {
-            throw new ApiException(ExceptionType.FORBIDDEN_USER);
+            throw DIARY_ACCESS_DENIED.defaultException();
         }
     }
 
@@ -91,7 +91,7 @@ public class DiaryService {
                                final DiaryRequest diaryRequest) {
         int count = diaryRepository.countDiaryOnDate(user.getId(), diaryRequest.referenceDate());
         if (count > 0) {
-            throw new ApiException(ExceptionType.BAD_REQUEST, "일기는 하루에 한개만 작성 가능합니다.");
+            throw DIARY_ALREADY_EXISTS.defaultException();
         }
     }
 }

--- a/src/main/java/com/muud/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/muud/global/error/GlobalExceptionHandler.java
@@ -1,26 +1,26 @@
-package com.muud.global.error;
-
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-@RestControllerAdvice
-@Slf4j
-public class GlobalExceptionHandler {
-
-    @ExceptionHandler(ApiException.class)
-    protected ResponseEntity<ResponseError> handleGlobalException(ApiException e) {
-        log.error(e.getMessage(), e);
-        return ResponseEntity.status(e.getExceptionType().getStatus())
-                .body(new ResponseError(e.getMessage()));
-    }
-
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    protected ResponseEntity<ResponseError> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-        log.error(e.getMessage(), e);
-        return ResponseEntity.status(ExceptionType.INVALID_INPUT_VALUE.getStatus())
-                .body(new ResponseError(e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
-    }
-}
+//package com.muud.global.error;
+//
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.MethodArgumentNotValidException;
+//import org.springframework.web.bind.annotation.ExceptionHandler;
+//import org.springframework.web.bind.annotation.RestControllerAdvice;
+//
+//@RestControllerAdvice
+//@Slf4j
+//public class GlobalExceptionHandler {
+//
+//    @ExceptionHandler(ApiException.class)
+//    protected ResponseEntity<ResponseError> handleGlobalException(ApiException e) {
+//        log.error(e.getMessage(), e);
+//        return ResponseEntity.status(e.getExceptionType().getStatus())
+//                .body(new ResponseError(e.getMessage()));
+//    }
+//
+//    @ExceptionHandler(MethodArgumentNotValidException.class)
+//    protected ResponseEntity<ResponseError> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+//        log.error(e.getMessage(), e);
+//        return ResponseEntity.status(ExceptionType.INVALID_INPUT_VALUE.getStatus())
+//                .body(new ResponseError(e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
+//    }
+//}

--- a/src/main/java/com/muud/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/muud/global/exception/GlobalExceptionHandler.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ApiResponseError> handleMemberException(CustomException e) {
+    public ResponseEntity<ApiResponseError> handleCustomException(CustomException e) {
         ApiResponseError response = ApiResponseError.from(e);
         HttpStatus httpStatus = e
                 .getErrorCode()

--- a/src/main/java/com/muud/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/muud/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,52 @@
+package com.muud.global.exception;
+
+
+import com.muud.global.error.ApiException;
+import com.muud.global.error.ExceptionType;
+import com.muud.global.error.ResponseError;
+import com.muud.global.exception.response.ApiResponseError;
+import com.muud.global.exception.support.CustomException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponseError> handleMemberException(CustomException e) {
+        ApiResponseError response = ApiResponseError.from(e);
+        HttpStatus httpStatus = e
+                .getErrorCode()
+                .defaultHttpStatus();
+        log.error(e.getMessage());
+        return new ResponseEntity<>(response, httpStatus);
+    }
+
+    //todo 추후 삭제
+    @ExceptionHandler(ApiException.class)
+    protected ResponseEntity<ResponseError> handleGlobalException(ApiException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(e.getExceptionType().getStatus())
+                .body(new ResponseError(e.getMessage()));
+    }
+
+    //todo 추후 변경
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ResponseError> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(ExceptionType.INVALID_INPUT_VALUE.getStatus())
+                .body(new ResponseError(e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponseError> handleAllExceptions(Exception e) {
+        ApiResponseError response = ApiResponseError.builder().build();
+        log.error(e.getMessage(), e);
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/muud/global/exception/response/ApiResponseError.java
+++ b/src/main/java/com/muud/global/exception/response/ApiResponseError.java
@@ -1,0 +1,68 @@
+package com.muud.global.exception.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.muud.global.exception.support.CustomException;
+import com.muud.global.exception.support.ErrorCode;
+import lombok.Builder;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ *
+ * @param code 에러 코드
+ * @param status HTTP 상태 코드
+ * @param name 오류명
+ * @param message 오류 메세지
+ * @param error HTTP 상태 코드 이름
+ * @param cause
+ * @param timestamp 발생 시간
+ */
+@Builder
+public record ApiResponseError(
+        String code,
+        Integer status,
+        String name,
+        String message,
+        String error,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY) List<ApiSimpleError> cause,
+        Instant timestamp
+) {
+    public static ApiResponseError from(CustomException exception) {
+        ErrorCode errorCode = exception.getErrorCode();
+        String errorName = exception.getClass().getName()
+                .substring(exception.getClass().getName().lastIndexOf(".") + 1);
+        String error = errorCode.defaultHttpStatus().name();
+
+        return ApiResponseError.builder()
+                .code(errorCode.name())
+                .status(errorCode.defaultHttpStatus().value())
+                .name(errorName)
+                .message(exception.getMessage())
+                .error(error)
+                .cause(ApiSimpleError.listOfCauseSimpleError(exception.getCause()))
+                .build();
+    }
+
+    public ApiResponseError {
+        if (code == null) {
+            code = "API_ERROR";
+        }
+
+        if (status == null) {
+            status = 500;
+        }
+
+        if (name == null) {
+            name = "ApiError";
+        }
+
+        if (message == null || message.isBlank()) {
+            message = "API 오류 - 로그를 확인하세요.";
+        }
+
+        if (timestamp == null) {
+            timestamp = Instant.now();
+        }
+    }
+}

--- a/src/main/java/com/muud/global/exception/response/ApiSimpleError.java
+++ b/src/main/java/com/muud/global/exception/response/ApiSimpleError.java
@@ -1,0 +1,39 @@
+package com.muud.global.exception.response;
+
+import jakarta.annotation.Nonnull;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ApiSimpleError(@Nonnull String field, @Nonnull String message) {
+
+    public static List<ApiSimpleError> listOfCauseSimpleError(Throwable cause) {
+        return List.of(arrayOfCauseSimpleError(cause));
+    }
+
+    public static ApiSimpleError[] arrayOfCauseSimpleError(Throwable cause) {
+        int depth = 0;
+        Throwable currentCause = cause;
+
+        while (currentCause != null) {
+            currentCause = currentCause.getCause();
+            depth++;
+        }
+
+        ApiSimpleError[] subErrors = new ApiSimpleError[depth];
+        currentCause = cause;
+        for (int i = 0; i < depth; i++) {
+            String errorFullName = currentCause.getClass().getSimpleName();
+            String field = errorFullName.substring(errorFullName.lastIndexOf('.') + 1);
+            subErrors[i] = ApiSimpleError.builder()
+                    .field(field)
+                    .message(currentCause.getLocalizedMessage())
+                    .build();
+
+            currentCause = currentCause.getCause();
+        }
+
+        return subErrors;
+    }
+}

--- a/src/main/java/com/muud/global/exception/support/CustomException.java
+++ b/src/main/java/com/muud/global/exception/support/CustomException.java
@@ -1,0 +1,70 @@
+package com.muud.global.exception.support;
+
+import org.springframework.http.HttpStatus;
+
+public class CustomException extends RuntimeException {
+
+    private static ErrorCode getDefaultErrorCode() {
+        return DefaultErrorCodeHolder.DEFAULT_ERROR_CODE;
+    }
+
+    protected final ErrorCode errorCode;
+
+    public CustomException() {
+        super(getDefaultErrorCode().defaultMessage());
+        this.errorCode = getDefaultErrorCode();
+    }
+
+    public CustomException(String message) {
+        super(message);
+        this.errorCode = getDefaultErrorCode();
+    }
+
+    public CustomException(String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = getDefaultErrorCode();
+    }
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.defaultMessage());
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.defaultMessage(), cause);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+    private static class DefaultErrorCodeHolder {
+        private static final ErrorCode DEFAULT_ERROR_CODE = new ErrorCode() {
+            @Override
+            public String name() {
+                return "SERVER_ERROR";
+            }
+
+            @Override
+            public HttpStatus defaultHttpStatus() {
+                return HttpStatus.INTERNAL_SERVER_ERROR;
+            }
+
+            @Override
+            public String defaultMessage() {
+                return "서버 오류";
+            }
+
+            @Override
+            public CustomException defaultException() {
+                return new CustomException(this);
+            }
+
+            @Override
+            public CustomException defaultException(Throwable cause) {
+                return new CustomException(this, cause);
+            }
+        };
+    }
+}

--- a/src/main/java/com/muud/global/exception/support/ErrorCode.java
+++ b/src/main/java/com/muud/global/exception/support/ErrorCode.java
@@ -1,0 +1,12 @@
+package com.muud.global.exception.support;
+
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    String name();
+    String defaultMessage();
+    HttpStatus defaultHttpStatus();
+    RuntimeException defaultException();
+    RuntimeException defaultException(Throwable cause);
+}


### PR DESCRIPTION
## Summary
도메인별로 예외 처리 할 수 있도록 변경하여 의존 방향 개선 및 독립적으로 관리

> 인터페이스를 통한 ErrorCode 확장과 도메인별로 CustomException 상속하여 관리

![스크린샷 2024-09-24 오후 5 33 33](https://github.com/user-attachments/assets/905b7334-a7cf-40f6-a0fc-28ca06a841c7)
## Describe your changes

- GlobalExceptionHandler에서 CustomException을 핸들링하도록 변경
- 500번대 에러 핸들링 케이스 추가
- ErrorResponse 필드들 추가
- CustomException 구현
- ErrorCode 인터페이스 구현
- DiaryException, DiaryErrorCode 생성
- DiaryService 예외 처리 로직 변경
- DiaryServiceTest 예외처리 로직 변경
- BookmarkException, BookmarkErrorCode 생성
- BookmarkService 예외 처리 로직 변경



## Issue number and link
#143 


## 공유사항 
### 변경 전, 후 Response
![스크린샷 2024-09-23 오후 7 06 33](https://github.com/user-attachments/assets/3587ad9e-7f24-4063-af28-cf42b57ba383)
변경 전 Response


![스크린샷 2024-09-23 오후 4 33 59](https://github.com/user-attachments/assets/89b98986-814e-4fbc-80de-099be064d03c)
변경 후 Response




## 구현 방법
1. 도메인별로 ErrorCode 인터페이스를 구현
2. CustomException 상속 및 구현
3. 예외처리가 필요한 곳에 CustomException를 상속받은 클래스를 생성 후 throw.

(e.g.)
`throw DiaryErrorCode.DIARY_ACCESS_DENIED.defaultException();`

`throw new DiaryException("custom message");`

`throw new DiaryException(DiaryErrorCode.DIARY_ACCESS_DENIED);`