### PR TITLE
feat: API 수행 시간 로깅 구현 #203

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'com.googlecode.json-simple:json-simple:1.1.1'

--- a/src/main/java/com/muud/global/aspect/ExecutionTimeAspect.java
+++ b/src/main/java/com/muud/global/aspect/ExecutionTimeAspect.java
@@ -1,0 +1,30 @@
+package com.muud.global.aspect;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j(topic = "ExecutionTimeLogger")
+public class ExecutionTimeAspect {
+
+    @Around("execution(* com.muud..controller..*(..))")
+    public Object execute(ProceedingJoinPoint joinPoint) throws Throwable {
+        long startTime = System.currentTimeMillis();
+        String methodName = joinPoint.getSignature().getName();
+
+        try {
+            Object result = joinPoint.proceed();
+            long executionTime = System.currentTimeMillis() - startTime;
+            log.info("실행 메서드: {}, 실행 시간: {}ms", methodName, executionTime);
+            return result;
+        } catch (Exception e) {
+            long executionTime = System.currentTimeMillis() - startTime;
+            log.info("실행 메서드: {}, 예외 발생: {}, 실행 시간: {}ms", methodName, e.getMessage(), executionTime);
+            throw e;
+        }
+    }
+}

--- a/src/test/java/com/muud/global/aspect/ExecutionTimeAspectTest.java
+++ b/src/test/java/com/muud/global/aspect/ExecutionTimeAspectTest.java
@@ -1,0 +1,61 @@
+package com.muud.global.aspect;
+
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ExecutionTimeAspectTest {
+
+    @Mock
+    private ProceedingJoinPoint proceedingJoinPoint;
+
+    @Mock
+    private MethodSignature methodSignature;
+
+    @InjectMocks
+    private ExecutionTimeAspect executionTimeAspect;
+
+    @Test
+    @DisplayName("로깅 메서드 호출 성공")
+    void execute_success() throws Throwable {
+        // given
+        when(proceedingJoinPoint.getSignature()).thenReturn(methodSignature);
+        when(proceedingJoinPoint.proceed()).thenReturn("test result");
+
+        // when
+        Object result = executionTimeAspect.execute(proceedingJoinPoint);
+
+        // then
+        assertEquals("test result", result);
+        verify(proceedingJoinPoint, times(1)).proceed();
+    }
+
+    @Test
+    @DisplayName("로깅 메서드 호출 실패 - 예외 던지기")
+    void testExecuteMethodWithException() throws Throwable {
+        // given
+        when(proceedingJoinPoint.getSignature()).thenReturn(methodSignature);
+        when(proceedingJoinPoint.proceed()).thenThrow(new RuntimeException("Test exception"));
+
+        // when
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            executionTimeAspect.execute(proceedingJoinPoint);
+        });
+
+        // then
+        assertEquals("Test exception", exception.getMessage());
+        verify(proceedingJoinPoint, times(1)).proceed();
+    }
+}


### PR DESCRIPTION
## Summary
![스크린샷 2024-09-25 오후 1 43 05](https://github.com/user-attachments/assets/ba8a4c36-afc5-43fa-beb5-e6f6a8e2dd6f)
컨트롤러의 수행시간을 로그로 찍는 기능을 AOP로 구현

> com.muud..controller 패키지 하위에 있는 모든 클래스를 탐지합니다

## Describe your changes
- 기능 구현
- 테스트코드 작성

## Issue number and link
#203