### PR TITLE
feat: 보관함 기능 API 추가 #214 

### DIFF
--- a/src/main/java/com/muud/library/controller/LibraryController.java
+++ b/src/main/java/com/muud/library/controller/LibraryController.java
@@ -14,10 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -39,10 +36,19 @@ public class LibraryController {
     @Operation(description = "보관함을 생성한다.", summary = "보관함 추가")
     @ApiResponse(responseCode = "201", description = "보관함 추가 성공")
     @PostMapping("/libraries")
-    public ResponseEntity<LibraryResponse> createCollection(@RequestParam String title,
-                                                            @RequestParam(required = false) Long playListId){
-        LibraryResponse libraryResponse = libraryService.createCollection(SecurityUtils.getCurrentUser(), title, playListId);
+    public ResponseEntity<LibraryResponse> createLibrary(@RequestParam String title,
+                                                         @RequestParam(required = false) Long playListId){
+        LibraryResponse libraryResponse = libraryService.createLibrary(SecurityUtils.getCurrentUser(), title, playListId);
         return ResponseEntity.created(URI.create("/libraries/"+libraryResponse.id()))
                 .body(libraryResponse);
     }
+
+    @Operation(description = "보관함을 삭제한다.", summary = "보관함 삭제")
+    @ApiResponse(responseCode = "204", description = "보관함 삭제 성공")
+    @DeleteMapping("/libraries/{libraryId}")
+    public ResponseEntity<Void> deleteLibrary(@PathVariable Long libraryId){
+        libraryService.deleteLibrary(libraryId);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/muud/library/controller/LibraryController.java
+++ b/src/main/java/com/muud/library/controller/LibraryController.java
@@ -1,12 +1,8 @@
 package com.muud.library.controller;
 
-import com.muud.collection.domain.dto.CollectionDto;
 import com.muud.global.common.PageResponse;
-import com.muud.global.util.SecurityUtils;
 import com.muud.library.domain.dto.LibraryResponse;
 import com.muud.library.service.LibraryService;
-import com.muud.playlist.domain.PlayList;
-import com.muud.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,8 +11,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
 import java.net.URI;
+import static com.muud.global.util.SecurityUtils.getCurrentUser;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,26 +25,52 @@ public class LibraryController {
     @ApiResponse(responseCode = "200")
     @GetMapping("/libraries")
     public ResponseEntity<PageResponse<LibraryResponse>> getLibraries(Pageable pageable){
-        Page<LibraryResponse> libraryResponses = libraryService.getLibraries(SecurityUtils.getCurrentUser(), pageable);
+        Page<LibraryResponse> libraryResponses = libraryService.getLibraries(getCurrentUser(), pageable);
         return ResponseEntity.ok(new PageResponse<>(libraryResponses));
+    }
+
+    @Operation(description = "사용자의 보관함을 조회한다. ", summary = "보관함 조회")
+    @ApiResponse(responseCode = "200")
+    @ApiResponse(responseCode = "404", description = "보관함이 존재하지 않음")
+    @ApiResponse(responseCode = "403", description = "보관함에 접근 권한이 없음")
+    @GetMapping("/libraries/{libraryId}")
+    public ResponseEntity<LibraryResponse> getLibrary(@PathVariable Long libraryId){
+        LibraryResponse libraryResponse = libraryService.getLibraryDetail(libraryId);
+        return ResponseEntity.ok(libraryResponse);
     }
 
     @Operation(description = "보관함을 생성한다.", summary = "보관함 추가")
     @ApiResponse(responseCode = "201", description = "보관함 추가 성공")
+    @ApiResponse(responseCode = "404", description = "플레이리스트가 존재하지 않음")
     @PostMapping("/libraries")
     public ResponseEntity<LibraryResponse> createLibrary(@RequestParam String title,
                                                          @RequestParam(required = false) Long playListId){
-        LibraryResponse libraryResponse = libraryService.createLibrary(SecurityUtils.getCurrentUser(), title, playListId);
+        LibraryResponse libraryResponse = libraryService.createLibrary(getCurrentUser(), title, playListId);
         return ResponseEntity.created(URI.create("/libraries/"+libraryResponse.id()))
                 .body(libraryResponse);
     }
 
     @Operation(description = "보관함을 삭제한다.", summary = "보관함 삭제")
     @ApiResponse(responseCode = "204", description = "보관함 삭제 성공")
+    @ApiResponse(responseCode = "404", description = "보관함이 존재하지 않음")
+    @ApiResponse(responseCode = "403", description = "보관함에 접근 권한이 없음")
     @DeleteMapping("/libraries/{libraryId}")
     public ResponseEntity<Void> deleteLibrary(@PathVariable Long libraryId){
         libraryService.deleteLibrary(libraryId);
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(description = "보관함에 플레이리스트를 추가한다.", summary = "플레이리스트 추가")
+    @ApiResponse(responseCode = "200", description = "플레이리스트 추가 성공")
+    @ApiResponse(responseCode = "404", description = "보관함이 존재하지 않음")
+    @ApiResponse(responseCode = "404", description = "플레이리스트가 존재하지 않음")
+    @ApiResponse(responseCode = "403", description = "보관함에 접근 권한이 없음")
+    @PostMapping("/libraries/{libraryId}/playlists")
+    public ResponseEntity<LibraryResponse> addPlayListToLibrary(@PathVariable Long libraryId,
+                                                                @RequestParam Long playListId) {
+        LibraryResponse libraryResponse = libraryService.addPlayList(libraryId, playListId);
+        return ResponseEntity.ok()
+                .body(libraryResponse);
     }
 
 }

--- a/src/main/java/com/muud/library/controller/LibraryController.java
+++ b/src/main/java/com/muud/library/controller/LibraryController.java
@@ -1,0 +1,48 @@
+package com.muud.library.controller;
+
+import com.muud.collection.domain.dto.CollectionDto;
+import com.muud.global.common.PageResponse;
+import com.muud.global.util.SecurityUtils;
+import com.muud.library.domain.dto.LibraryResponse;
+import com.muud.library.service.LibraryService;
+import com.muud.playlist.domain.PlayList;
+import com.muud.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "보관함 API", description = "보관함 관련 CRUD")
+public class LibraryController {
+
+    private final LibraryService libraryService;
+
+    @Operation(description = "사용자의 보관함 리스트를 조회한다. ", summary = "보관함 리스트 조회")
+    @ApiResponse(responseCode = "200")
+    @GetMapping("/libraries")
+    public ResponseEntity<PageResponse<LibraryResponse>> getLibraries(Pageable pageable){
+        Page<LibraryResponse> libraryResponses = libraryService.getLibraries(SecurityUtils.getCurrentUser(), pageable);
+        return ResponseEntity.ok(new PageResponse<>(libraryResponses));
+    }
+
+    @Operation(description = "보관함을 생성한다.", summary = "보관함 추가")
+    @ApiResponse(responseCode = "201", description = "보관함 추가 성공")
+    @PostMapping("/libraries")
+    public ResponseEntity<LibraryResponse> createCollection(@RequestParam String title,
+                                                            @RequestParam(required = false) Long playListId){
+        LibraryResponse libraryResponse = libraryService.createCollection(SecurityUtils.getCurrentUser(), title, playListId);
+        return ResponseEntity.created(URI.create("/libraries/"+libraryResponse.id()))
+                .body(libraryResponse);
+    }
+}

--- a/src/main/java/com/muud/library/domain/dto/LibraryResponse.java
+++ b/src/main/java/com/muud/library/domain/dto/LibraryResponse.java
@@ -1,11 +1,16 @@
 package com.muud.library.domain.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.muud.playlist.domain.dto.VideoDto;
 import java.util.List;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record LibraryResponse (
         Long id,
         String title,
         List<VideoDto> playLists
 ) {
+    public LibraryResponse(Long id, String title) {
+        this(id, title, null);
+    }
 }

--- a/src/main/java/com/muud/library/domain/dto/LibraryResponse.java
+++ b/src/main/java/com/muud/library/domain/dto/LibraryResponse.java
@@ -1,0 +1,2 @@
+package com.muud.library.domain.dto;public class LibraryResponse {
+}

--- a/src/main/java/com/muud/library/domain/dto/LibraryResponse.java
+++ b/src/main/java/com/muud/library/domain/dto/LibraryResponse.java
@@ -1,2 +1,11 @@
-package com.muud.library.domain.dto;public class LibraryResponse {
+package com.muud.library.domain.dto;
+
+import com.muud.playlist.domain.dto.VideoDto;
+import java.util.List;
+
+public record LibraryResponse (
+        Long id,
+        String title,
+        List<VideoDto> playLists
+) {
 }

--- a/src/main/java/com/muud/library/domain/entity/Library.java
+++ b/src/main/java/com/muud/library/domain/entity/Library.java
@@ -1,0 +1,33 @@
+package com.muud.library.domain.entity;
+
+import com.muud.global.common.BaseEntity;
+import com.muud.playlist.domain.PlayList;
+import com.muud.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Library extends BaseEntity {
+
+    @Id
+    @Column(name = "library_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User owner;
+
+    @OneToMany(mappedBy = "library", cascade = CascadeType.ALL)
+    private List<LibraryPlayList> libraryPlayLists = new ArrayList<>();
+
+}

--- a/src/main/java/com/muud/library/domain/entity/Library.java
+++ b/src/main/java/com/muud/library/domain/entity/Library.java
@@ -5,6 +5,7 @@ import com.muud.playlist.domain.PlayList;
 import com.muud.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -30,4 +31,16 @@ public class Library extends BaseEntity {
     @OneToMany(mappedBy = "library", cascade = CascadeType.ALL)
     private List<LibraryPlayList> libraryPlayLists = new ArrayList<>();
 
+    @Builder
+    public Library(String title, User owner, List<LibraryPlayList> libraryPlayLists) {
+        this.title = title;
+        this.owner = owner;
+        this.libraryPlayLists = libraryPlayLists;
+    }
+
+    public void addPlayList(LibraryPlayList playList) {
+        if(libraryPlayLists==null)
+            libraryPlayLists = new ArrayList<>();
+        libraryPlayLists.add(playList);
+    }
 }

--- a/src/main/java/com/muud/library/domain/entity/Library.java
+++ b/src/main/java/com/muud/library/domain/entity/Library.java
@@ -1,7 +1,6 @@
 package com.muud.library.domain.entity;
 
 import com.muud.global.common.BaseEntity;
-import com.muud.playlist.domain.PlayList;
 import com.muud.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/muud/library/domain/entity/LibraryPlayList.java
+++ b/src/main/java/com/muud/library/domain/entity/LibraryPlayList.java
@@ -1,0 +1,27 @@
+package com.muud.library.domain.entity;
+
+import com.muud.playlist.domain.PlayList;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LibraryPlayList {
+
+    @Id
+    @Column(name = "library_playlist_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "library_id")
+    private Library library;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "playlist_id")
+    private PlayList playList;
+
+}

--- a/src/main/java/com/muud/library/domain/entity/LibraryPlayList.java
+++ b/src/main/java/com/muud/library/domain/entity/LibraryPlayList.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "library_playlist")
 public class LibraryPlayList {
 
     @Id

--- a/src/main/java/com/muud/library/domain/entity/LibraryPlayList.java
+++ b/src/main/java/com/muud/library/domain/entity/LibraryPlayList.java
@@ -3,6 +3,7 @@ package com.muud.library.domain.entity;
 import com.muud.playlist.domain.PlayList;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,4 +26,9 @@ public class LibraryPlayList {
     @JoinColumn(name = "playlist_id")
     private PlayList playList;
 
+    @Builder
+    public LibraryPlayList(Library library, PlayList playList) {
+        this.library = library;
+        this.playList = playList;
+    }
 }

--- a/src/main/java/com/muud/library/domain/mapper/LibraryMapper.java
+++ b/src/main/java/com/muud/library/domain/mapper/LibraryMapper.java
@@ -1,2 +1,34 @@
-package com.muud.library.domain.mapper;public class LibraryMapper {
+package com.muud.library.domain.mapper;
+
+import com.muud.library.domain.dto.LibraryResponse;
+import com.muud.library.domain.entity.Library;
+import com.muud.library.domain.entity.LibraryPlayList;
+import com.muud.playlist.domain.dto.VideoDto;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class LibraryMapper {
+
+    public LibraryResponse toResponse(Library library) {
+        return new LibraryResponse(
+                library.getId(),
+                library.getTitle(),
+                mapLibraryPlayListsToVideoDtos(library.getLibraryPlayLists())
+        );
+    }
+
+    public List<VideoDto> mapLibraryPlayListsToVideoDtos(List<LibraryPlayList> libraryPlayLists) {
+        if (libraryPlayLists == null) {
+            return Collections.emptyList();
+        }
+
+        return libraryPlayLists.stream()
+                .map(libraryPlayList -> libraryPlayList.getPlayList().toDto())
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/com/muud/library/domain/mapper/LibraryMapper.java
+++ b/src/main/java/com/muud/library/domain/mapper/LibraryMapper.java
@@ -3,7 +3,9 @@ package com.muud.library.domain.mapper;
 import com.muud.library.domain.dto.LibraryResponse;
 import com.muud.library.domain.entity.Library;
 import com.muud.library.domain.entity.LibraryPlayList;
+import com.muud.playlist.domain.PlayList;
 import com.muud.playlist.domain.dto.VideoDto;
+import com.muud.user.entity.User;
 import org.springframework.stereotype.Component;
 
 import java.util.Collections;
@@ -17,11 +19,11 @@ public class LibraryMapper {
         return new LibraryResponse(
                 library.getId(),
                 library.getTitle(),
-                mapLibraryPlayListsToVideoDtos(library.getLibraryPlayLists())
+                toLibraryPlayListsToVideoDtos(library.getLibraryPlayLists())
         );
     }
 
-    public List<VideoDto> mapLibraryPlayListsToVideoDtos(List<LibraryPlayList> libraryPlayLists) {
+    public List<VideoDto> toLibraryPlayListsToVideoDtos(List<LibraryPlayList> libraryPlayLists) {
         if (libraryPlayLists == null) {
             return Collections.emptyList();
         }
@@ -31,4 +33,17 @@ public class LibraryMapper {
                 .collect(Collectors.toList());
     }
 
+    public Library toLibrary(User user, String title) {
+        return Library.builder()
+                .owner(user)
+                .title(title)
+                .build();
+    }
+
+    public LibraryPlayList toLibraryPlayList(Library library, PlayList playList) {
+        return LibraryPlayList.builder()
+                .library(library)
+                .playList(playList)
+                .build();
+    }
 }

--- a/src/main/java/com/muud/library/domain/mapper/LibraryMapper.java
+++ b/src/main/java/com/muud/library/domain/mapper/LibraryMapper.java
@@ -6,16 +6,16 @@ import com.muud.library.domain.entity.LibraryPlayList;
 import com.muud.playlist.domain.PlayList;
 import com.muud.playlist.domain.dto.VideoDto;
 import com.muud.user.entity.User;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
-
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Component
 public class LibraryMapper {
 
-    public LibraryResponse toResponse(Library library) {
+    public LibraryResponse toResponse(final Library library) {
         return new LibraryResponse(
                 library.getId(),
                 library.getTitle(),
@@ -23,24 +23,28 @@ public class LibraryMapper {
         );
     }
 
-    public List<VideoDto> toLibraryPlayListsToVideoDtos(List<LibraryPlayList> libraryPlayLists) {
-        if (libraryPlayLists == null) {
-            return Collections.emptyList();
-        }
+    public Page<LibraryResponse> toLibraryResponses(final Page<Library> libraries) {
+        return libraries.map(library -> new LibraryResponse(
+                library.getId(),
+                library.getTitle()
+        ));
+    }
 
-        return libraryPlayLists.stream()
+    public List<VideoDto> toLibraryPlayListsToVideoDtos(final List<LibraryPlayList> libraryPlayLists) {
+        return Stream.ofNullable(libraryPlayLists)
+                .flatMap(List::stream)
                 .map(libraryPlayList -> libraryPlayList.getPlayList().toDto())
                 .collect(Collectors.toList());
     }
 
-    public Library toLibrary(User user, String title) {
+    public Library toLibrary(final User user, final String title) {
         return Library.builder()
                 .owner(user)
                 .title(title)
                 .build();
     }
 
-    public LibraryPlayList toLibraryPlayList(Library library, PlayList playList) {
+    public LibraryPlayList toLibraryPlayList(final Library library, final PlayList playList) {
         return LibraryPlayList.builder()
                 .library(library)
                 .playList(playList)

--- a/src/main/java/com/muud/library/domain/mapper/LibraryMapper.java
+++ b/src/main/java/com/muud/library/domain/mapper/LibraryMapper.java
@@ -1,0 +1,2 @@
+package com.muud.library.domain.mapper;public class LibraryMapper {
+}

--- a/src/main/java/com/muud/library/exception/LibraryErrorCode.java
+++ b/src/main/java/com/muud/library/exception/LibraryErrorCode.java
@@ -1,0 +1,37 @@
+package com.muud.library.exception;
+
+import com.muud.global.exception.support.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum LibraryErrorCode implements ErrorCode {
+    LIBRARY_NOT_FOUND("해당 보관함을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    FORBIDDEN_USER("해당 보관함에 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    ALREADY_ADDED_PLAYLIST("해당 플레이리스트가 보관함에 이미 존재합니다.", HttpStatus.CONFLICT),
+    DEFAULT("보관함을 불러오던 중 에러가 발생하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String message;
+    private final HttpStatus status;
+
+
+    @Override
+    public String defaultMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus defaultHttpStatus() {
+        return status;
+    }
+
+    @Override
+    public RuntimeException defaultException() {
+        return new LibraryException(this);
+    }
+
+    @Override
+    public RuntimeException defaultException(Throwable cause) {
+        return new LibraryException(this, cause);
+    }
+}

--- a/src/main/java/com/muud/library/exception/LibraryException.java
+++ b/src/main/java/com/muud/library/exception/LibraryException.java
@@ -1,0 +1,27 @@
+package com.muud.library.exception;
+
+import com.muud.global.exception.support.CustomException;
+import com.muud.global.exception.support.ErrorCode;
+
+public class LibraryException extends CustomException {
+
+    public LibraryException() {
+        super();
+    }
+
+    public LibraryException(String message) {
+        super(message);
+    }
+
+    public LibraryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public LibraryException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public LibraryException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+}

--- a/src/main/java/com/muud/library/repository/LibraryRepository.java
+++ b/src/main/java/com/muud/library/repository/LibraryRepository.java
@@ -1,0 +1,11 @@
+package com.muud.library.repository;
+
+import com.muud.library.domain.entity.Library;
+import com.muud.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LibraryRepository extends JpaRepository<Library, Long> {
+    Page<Library> findByOwner(User user, Pageable pageable);
+}

--- a/src/main/java/com/muud/library/service/LibraryService.java
+++ b/src/main/java/com/muud/library/service/LibraryService.java
@@ -15,6 +15,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.muud.library.exception.LibraryErrorCode.FORBIDDEN_USER;
+import static com.muud.library.exception.LibraryErrorCode.LIBRARY_NOT_FOUND;
 import static com.muud.playlist.exception.PlayListErrorCode.PLAY_LIST_NOT_FOUND;
 
 @Service
@@ -26,40 +28,105 @@ public class LibraryService {
     private final PlayListRepository playListRepository;
     private final LibraryMapper libraryMapper;
 
-    public Page<LibraryResponse> getLibraries(User user, Pageable pageable) {
+    /**
+     * 사용자의 보관함 목록을 조회합니다.
+     *
+     * @param user 조회할 보관함의 소유자 (로그인한 사용자)
+     * @param pageable 페이지 정보 (페이지 번호, 크기 등)
+     * @return 보관함 목록의 페이지 (LibraryResponse 형태)
+     */
+    public Page<LibraryResponse> getLibraries(final User user,
+                                              final Pageable pageable) {
         Page<Library> libraries = libraryRepository.findByOwner(user, pageable);
-        return libraries.map(libraryMapper::toResponse);
+        return libraryMapper.toLibraryResponses(libraries);
     }
 
+    /**
+     * 사용자의 보관함을 추가합니다.
+     *
+     * @param user 조회할 보관함의 소유자 (로그인한 사용자)
+     * @param title 보관함 타이틀
+     * @param playListId 보관함 생성과 동시에 들어갈 playList Id(Nullable)
+     * @return 보관함 목록의 페이지 (LibraryResponse 형태)
+     */
     @Transactional
-    public LibraryResponse createLibrary(User user, String title, Long playListId) {
+    public LibraryResponse createLibrary(final User user,
+                                         final String title,
+                                         final Long playListId) {
         Library library = libraryMapper.toLibrary(user, title);
         if(playListId!=null) {
-            PlayList playList = getPlayList(playListId);
-            LibraryPlayList libraryPlayList = libraryMapper.toLibraryPlayList(library, playList);
-            library.addPlayList(libraryPlayList);
+            addPlayListToLibrary(library, playListId);
         }
         libraryRepository.save(library);
         return libraryMapper.toResponse(library);
     }
 
-    public PlayList getPlayList(Long playListId) {
-        return playListRepository.findById(playListId)
-                .orElseThrow(PLAY_LIST_NOT_FOUND::defaultException);
-    }
-
+    /**
+     * 사용자의 보관함을 삭제합니다.
+     *
+     * @param libraryId 삭제할 보관함 Id
+     */
     @Transactional
-    public void deleteLibrary(Long libraryId) {
+    public void deleteLibrary(final Long libraryId) {
         Library library = getLibrary(libraryId);
         libraryRepository.delete(library);
     }
 
-    public Library getLibrary(Long libraryId) {
+    /**
+     * 사용자의 보관함 정보를 조회합니다.
+     *
+     * @param libraryId 조회할 보관함의 Id
+     * @return 보관함 목록의 페이지 (LibraryResponse 형태)
+     */
+    public LibraryResponse getLibraryDetail(final Long libraryId) {
+        Library library = getLibrary(libraryId);
+        return libraryMapper.toResponse(library);
+    }
+
+    /**
+     * 보관함을 조회하고 권한을 확인합니다.
+     *
+     * @param libraryId 조회할 보관함의 Id
+     * @return 보관함 목록의 페이지 (LibraryResponse 형태)
+     */
+    public Library getLibrary(final Long libraryId) {
         Library library = libraryRepository.findById(libraryId)
-                .orElseThrow();
+                .orElseThrow(LIBRARY_NOT_FOUND::defaultException);
         if(!SecurityUtils.checkCurrentUserId(library.getOwner().getId())){
-            throw new RuntimeException();
+            throw FORBIDDEN_USER.defaultException();
         }
         return library;
     }
+
+    /**
+     * 보관함에 PlayList를 추가합니다.
+     *
+     * @param libraryId 보관함 Id
+     * @param playListId 추가할 PlayList의 Id
+     * @return 보관함 목록의 페이지 (LibraryResponse 형태)
+     */
+    @Transactional
+    public LibraryResponse addPlayList(final Long libraryId,
+                                       final Long playListId) {
+        Library library = getLibrary(libraryId);
+        addPlayListToLibrary(library, playListId);
+        return libraryMapper.toResponse(library);
+    }
+
+
+    /**
+     * 보관함에 PlayList를 추가합니다.
+     *
+     * @param library PlayList를 추가할 보관함
+     * @param playListId 추가할 PlayList의 Id
+     * @return 보관함 목록의 페이지 (LibraryResponse 형태)
+     */
+    public void addPlayListToLibrary(final Library library,
+                                     final Long playListId) {
+        PlayList playList = playListRepository.findById(playListId)
+                .orElseThrow(PLAY_LIST_NOT_FOUND::defaultException);
+        LibraryPlayList libraryPlayList = libraryMapper.toLibraryPlayList(library, playList);
+        library.addPlayList(libraryPlayList);
+    }
+
 }

--- a/src/main/java/com/muud/library/service/LibraryService.java
+++ b/src/main/java/com/muud/library/service/LibraryService.java
@@ -2,19 +2,25 @@ package com.muud.library.service;
 
 import com.muud.library.domain.dto.LibraryResponse;
 import com.muud.library.domain.entity.Library;
+import com.muud.library.domain.entity.LibraryPlayList;
 import com.muud.library.domain.mapper.LibraryMapper;
 import com.muud.library.repository.LibraryRepository;
+import com.muud.playlist.domain.PlayList;
+import com.muud.playlist.repository.PlayListRepository;
 import com.muud.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import static com.muud.playlist.exception.PlayListErrorCode.PLAY_LIST_NOT_FOUND;
+
 @Service
 @RequiredArgsConstructor
 public class LibraryService {
 
     private final LibraryRepository libraryRepository;
+    private final PlayListRepository playListRepository;
     private final LibraryMapper libraryMapper;
 
     public Page<LibraryResponse> getLibraries(User user, Pageable pageable) {
@@ -22,4 +28,19 @@ public class LibraryService {
         return libraries.map(libraryMapper::toResponse);
     }
 
+    public LibraryResponse createCollection(User user, String title, Long playListId) {
+        Library library = libraryMapper.toLibrary(user, title);
+        if(playListId!=null) {
+            PlayList playList = getPlayList(playListId);
+            LibraryPlayList libraryPlayList = libraryMapper.toLibraryPlayList(library, playList);
+            library.addPlayList(libraryPlayList);
+        }
+        libraryRepository.save(library);
+        return libraryMapper.toResponse(library);
+    }
+
+    public PlayList getPlayList(Long playListId) {
+        return playListRepository.findById(playListId)
+                .orElseThrow(PLAY_LIST_NOT_FOUND::defaultException);
+    }
 }

--- a/src/main/java/com/muud/library/service/LibraryService.java
+++ b/src/main/java/com/muud/library/service/LibraryService.java
@@ -1,0 +1,25 @@
+package com.muud.library.service;
+
+import com.muud.library.domain.dto.LibraryResponse;
+import com.muud.library.domain.entity.Library;
+import com.muud.library.domain.mapper.LibraryMapper;
+import com.muud.library.repository.LibraryRepository;
+import com.muud.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LibraryService {
+
+    private final LibraryRepository libraryRepository;
+    private final LibraryMapper libraryMapper;
+
+    public Page<LibraryResponse> getLibraries(User user, Pageable pageable) {
+        Page<Library> libraries = libraryRepository.findByOwner(user, pageable);
+        return libraries.map(libraryMapper::toResponse);
+    }
+
+}

--- a/src/test/java/com/muud/library/service/LibraryServiceTest.java
+++ b/src/test/java/com/muud/library/service/LibraryServiceTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class LibraryServiceTest {
+  
+}

--- a/src/test/java/com/muud/library/service/LibraryServiceTest.java
+++ b/src/test/java/com/muud/library/service/LibraryServiceTest.java
@@ -1,4 +1,66 @@
-import static org.junit.jupiter.api.Assertions.*;
+package com.muud.library.service;
+
+import com.muud.library.domain.dto.LibraryResponse;
+import com.muud.library.domain.entity.Library;
+import com.muud.library.repository.LibraryRepository;
+import com.muud.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
 class LibraryServiceTest {
-  
+
+    @InjectMocks
+    private LibraryService libraryService;
+
+    @Mock
+    private LibraryRepository libraryRepository;
+
+    private User user;
+    private Library library;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .email("test@example.com")
+                .nickname("test")
+                .password("encryptedPassword")
+                .build();
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        library = Library.builder()
+                .owner(user)
+                .title("My Library")
+                .build();
+    }
+
+    @Test
+    @DisplayName("user의 보관함 리스트를 가져온다.")
+    void getLibraries_ReturnsLibraryResponses() {
+        //given
+        Pageable pageable = Pageable.ofSize(10);
+        Page<Library> mockPage = new PageImpl<>(Collections.singletonList(library), pageable, 1);
+        when(libraryRepository.findByOwner(user, pageable)).thenReturn(mockPage);
+
+        // when
+        Page<LibraryResponse> result = libraryService.getLibraries(user, pageable);
+
+        // then
+        assertEquals(1, result.getTotalElements());
+        assertEquals("My Library", result.getContent().get(0).title());
+    }
 }

--- a/src/test/java/com/muud/library/service/LibraryServiceTest.java
+++ b/src/test/java/com/muud/library/service/LibraryServiceTest.java
@@ -1,8 +1,18 @@
 package com.muud.library.service;
 
+import com.muud.auth.service.UserPrincipal;
+import com.muud.emotion.domain.Emotion;
 import com.muud.library.domain.dto.LibraryResponse;
 import com.muud.library.domain.entity.Library;
+import com.muud.library.domain.entity.LibraryPlayList;
+import com.muud.library.domain.mapper.LibraryMapper;
+import com.muud.library.exception.LibraryErrorCode;
+import com.muud.library.exception.LibraryException;
 import com.muud.library.repository.LibraryRepository;
+import com.muud.playlist.domain.PlayList;
+import com.muud.playlist.exception.PlayListErrorCode;
+import com.muud.playlist.exception.PlayListException;
+import com.muud.playlist.repository.PlayListRepository;
 import com.muud.user.entity.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -14,11 +24,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.util.ReflectionTestUtils;
-
 import java.util.Collections;
-
+import java.util.Optional;
+import static com.amazonaws.util.ValidationUtils.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,8 +44,22 @@ class LibraryServiceTest {
     @Mock
     private LibraryRepository libraryRepository;
 
+    @Mock
+    private LibraryMapper libraryMapper;
+
+    @Mock
+    private PlayListRepository playListRepository;
+
+    @Mock
+    private Authentication authentication;
+
+    @Mock
+    private SecurityContext securityContext;
+
     private User user;
+    private UserPrincipal userPrincipal;
     private Library library;
+    private PlayList playList;
 
     @BeforeEach
     void setUp() {
@@ -46,21 +74,158 @@ class LibraryServiceTest {
                 .owner(user)
                 .title("My Library")
                 .build();
+
+        playList = PlayList.builder()
+                .title("My PlayList")
+                .emotion(Emotion.JOY)
+                .build();
+        ReflectionTestUtils.setField(playList, "id", 1L);
     }
 
+    private void mockSecurity() {
+        userPrincipal = new UserPrincipal(user);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(userPrincipal);
+        SecurityContextHolder.setContext(securityContext);
+    }
     @Test
     @DisplayName("user의 보관함 리스트를 가져온다.")
     void getLibraries_ReturnsLibraryResponses() {
-        //given
+        // given
         Pageable pageable = Pageable.ofSize(10);
-        Page<Library> mockPage = new PageImpl<>(Collections.singletonList(library), pageable, 1);
-        when(libraryRepository.findByOwner(user, pageable)).thenReturn(mockPage);
+        Page<Library> libraries = new PageImpl<>(Collections.singletonList(library), pageable, 1);
+        LibraryResponse libraryResponse = new LibraryResponse(library.getId(), library.getTitle()); // Create LibraryResponse from Library
+        when(libraryRepository.findByOwner(user, pageable)).thenReturn(libraries);
+        when(libraryMapper.toLibraryResponses(libraries)).thenReturn(new PageImpl<>(Collections.singletonList(libraryResponse))); // Mock the mapper
 
         // when
         Page<LibraryResponse> result = libraryService.getLibraries(user, pageable);
 
         // then
         assertEquals(1, result.getTotalElements());
-        assertEquals("My Library", result.getContent().get(0).title());
+        assertNotNull(result.getContent(), "The content should not be null");
+        assertEquals(library.getTitle(), result.getContent().get(0).title());
+    }
+
+
+    @Test
+    @DisplayName("보관함을 PlayList 없이 생성한다.")
+    void createLibrary_CreatesLibrarySuccessfully() {
+        // given
+        String title = "My Library";
+        when(libraryMapper.toLibrary(user, title)).thenReturn(library);
+        when(libraryRepository.save(library)).thenReturn(library);
+        when(libraryMapper.toResponse(library)).thenReturn(new LibraryResponse(library.getId(), library.getTitle()));
+
+        // when
+        LibraryResponse result = libraryService.createLibrary(user, title, null);
+
+        // then
+        assertEquals(title, result.title());
+        assertEquals(library.getId(), result.id());
+    }
+
+    @Test
+    @DisplayName("보관함 생성과 함께 플레이리스트를 추가한다.")
+    void createLibraryWithPlayList_CreatesLibraryWithPlayListSuccessfully() {
+        // given
+        when(libraryMapper.toLibrary(user, library.getTitle())).thenReturn(library);
+        when(playListRepository.findById(playList.getId())).thenReturn(Optional.of(playList));
+        when(libraryRepository.save(library)).thenReturn(library);
+        when(libraryMapper.toResponse(library)).thenReturn(new LibraryResponse(library.getId(), library.getTitle(), Collections.singletonList(playList.toDto())));
+
+        // when
+        LibraryResponse result = libraryService.createLibrary(user, library.getTitle(), playList.getId());
+
+        // then
+        assertEquals(playList.getTitle(), result.playLists().get(0).getTitle());
+        assertEquals(library.getId(), result.id());
+    }
+
+    @Test
+    @DisplayName("보관함 생성과 함께 존재하지 않는 플레이리스트를 추가하면 PlayListException::PLAY_LIST_NOT_FOUND가 발생한다")
+    void createLibraryWithPlayList_PlayList_Not_Exist() {
+        // given
+        when(libraryMapper.toLibrary(user, library.getTitle())).thenReturn(library);
+        when(playListRepository.findById(playList.getId())).thenReturn(Optional.empty());
+
+        // when
+        PlayListException exception = assertThrows(PlayListException.class, () ->
+                libraryService.createLibrary(user, library.getTitle(), playList.getId())
+        );
+
+        // then
+        assertEquals(exception.getErrorCode(), PlayListErrorCode.PLAY_LIST_NOT_FOUND);
+
+    }
+    @Test
+    @DisplayName("보관함 정보를 조회한다.")
+    void getLibraryDetail_ReturnsLibraryDetail() {
+        // given
+        Long libraryId = 1L;
+        when(libraryRepository.findById(libraryId)).thenReturn(Optional.of(library));
+        when(libraryMapper.toResponse(library)).thenReturn(new LibraryResponse(library.getId(), library.getTitle()));
+        mockSecurity();
+
+        // when
+        LibraryResponse result = libraryService.getLibraryDetail(libraryId);
+
+        // then
+        assertEquals(library.getId(), result.id());
+        assertEquals(library.getTitle(), result.title());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 보관함 정보를 조회하면 LibraryException::LIBRARY_NOT_FOUND가 발생한다")
+    void getLibraryDetail_NotExist() {
+        // given
+        Long libraryId = 1L;
+        when(libraryRepository.findById(libraryId)).thenReturn(Optional.empty());
+
+        // when
+        LibraryException exception = assertThrows(LibraryException.class, () -> libraryService.getLibraryDetail(libraryId));
+
+        // then
+        assertEquals(exception.getErrorCode(), LibraryErrorCode.LIBRARY_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("보관함을 삭제한다.")
+    void deleteLibrary_DeletesLibrarySuccessfully() {
+        // given
+        Long libraryId = 1L;
+        when(libraryRepository.findById(libraryId)).thenReturn(Optional.of(library));
+        mockSecurity();
+
+        // when
+        libraryService.deleteLibrary(libraryId);
+
+        // then
+        assertEquals("My Library", library.getTitle());
+    }
+
+    @Test
+    @DisplayName("보관함에 플레이리스트를 추가한다.")
+    void addPlayListToLibrary_successfully() {
+        // given
+        Long libraryId = 1L;
+        Long playListId = 1L;
+
+        // 라이브러리 및 플레이리스트 반환 값 설정
+        when(libraryRepository.findById(libraryId)).thenReturn(java.util.Optional.of(library));
+        when(playListRepository.findById(playListId)).thenReturn(java.util.Optional.of(playList));
+        LibraryPlayList libraryPlayList = new LibraryPlayList(library, playList);
+        when(libraryMapper.toLibraryPlayList(library, playList)).thenReturn(libraryPlayList);
+        when(libraryMapper.toResponse(library)).thenReturn(new LibraryResponse(libraryId, library.getTitle(), Collections.singletonList(playList.toDto())));
+        library.addPlayList(libraryPlayList);
+        mockSecurity();
+
+        // when
+        LibraryResponse result = libraryService.addPlayList(libraryId, playListId);
+
+        // then
+        assertEquals(libraryId, result.id(), "라이브러리 ID가 일치해야 합니다.");
+        assertEquals(library.getTitle(), result.title());
+        assertEquals(library.getLibraryPlayLists().get(0).getPlayList().getTitle(), playList.getTitle());
     }
 }


### PR DESCRIPTION
## Summary
새롭게 정의된 보관함 기능 관련 API 추가 개발 #214 

## Describe your changes
### 1. New Entity
- **Library**: 사용자의 보관함을 나타내며, 사용자는 여러 개의 보관함을 가질 수 있음.
- **LibraryPlayList**: 보관함과 플레이리스트 간의 관계를 매핑하는 중간 엔티티로, 다대다 관계를 관리.

### 2. Library API 추가
- **보관함 목록 조회, 생성, 삭제, 상세 조회**
- **보관함에 플레이리스트 추가/삭제** 기능 구현.
- 관련 Controller, Service, Repository 생성 및 로직 구현.
- **LibraryMapper**: 보관함 관련 DTO와 엔티티 간의 변환을 담당.

### 3. Custom Exception 및 Error Code 정의
- 보관함 관련 에러 처리 및 커스텀 예외 추가.

### 4. Unit Test
- **LibraryService**의 주요 기능에 대한 단위 테스트 구현.

## Issue number and link
#214 

## 추가 사항
- 보관함에서 플레이리스트 삭제하는 기능은 별도로 PR을 통해 추가할 예정입니다.
- 리뷰 후 개선 사항 반영하여 **Library** 및 **LibraryPlayList** 테이블 생성 작업을 진행할 예정입니다.